### PR TITLE
add CRUD operations with PHOTOS

### DIFF
--- a/.idea/PhotoShare-REST-API.iml
+++ b/.idea/PhotoShare-REST-API.iml
@@ -2,7 +2,7 @@
 <module type="PYTHON_MODULE" version="4">
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$" />
-    <orderEntry type="inheritedJdk" />
+    <orderEntry type="jdk" jdkName="Python 3.12" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,5 +3,5 @@
   <component name="Black">
     <option name="sdkName" value="Python 3.9" />
   </component>
-  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.9" project-jdk-type="Python SDK" />
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.12" project-jdk-type="Python SDK" />
 </project>

--- a/README.md
+++ b/README.md
@@ -106,27 +106,27 @@ After starting the server, navigate to `http://127.0.0.1:8000/docs` to explore t
 
 ## API Endpoints
 
-### Contact Management
+### Photo management
 
-- **Create a new contact**
-  - `POST /api/contacts/`
-  - Create a new contact with the provided details.
+- **Create a new photo**
+- `POST /api/photos/`
+- Create a new photo with a description
+- available to all users
 
-- **Get all contacts**
-  - `GET /api/contacts/`
-  - Retrieve a list of all contacts.
+- **Delete photo by ID**
+- `DELETE /api/photos/{photo_id}`
+- Delete photo from the database and from Cloud
+- Available only to photo owners and administrators
 
-- **Get a contact by ID**
-  - `GET /api/contacts/{contact_id}`
-  - Retrieve a specific contact by its ID.
+- **Update photo description by ID**
+- `PUT /api/photos/{photo_id}`
+- Update description of an existing photo
+- - Available only to photo owners and administrators
 
-- **Update a contact by ID**
-  - `PUT /api/contacts/{contact_id}`
-  - Update the details of an existing contact.
-
-- **Delete a contact by ID**
-  - `DELETE /api/contacts/{contact_id}`
-  - Remove a contact from the database.
+- **Get a photo by ID**
+- `GET /api/photos/{photo_id}`
+- Get a specific photo by its ID
+- Available only to photo owners and administrators
 
 ### Authentication Endpoints
 

--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from src.routes import users, auth
+from src.routes import users, auth, photos
 from src.database.db import get_db
 from src.services.middlewares import ProcessTimeHeaderMiddleware
 from src.conf.config import config
@@ -28,6 +28,7 @@ app.add_middleware(
 
 app.include_router(auth.router, prefix='/api')
 app.include_router(users.routerUsers, prefix='/api')
+app.include_router(photos.routerPhotos, prefix='/api')
 
 
 @app.on_event("startup")

--- a/src/repository/photos.py
+++ b/src/repository/photos.py
@@ -1,0 +1,86 @@
+import datetime
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.entity.models import Photo
+
+
+async def add_photo(url: str, description: str, db: AsyncSession, user_id: int) -> Photo:
+    """Adds a new photo to the database.
+
+    Args:
+        url (str): The URL of the photo.
+        description (str): The description of the photo.
+        db (AsyncSession): The database session.
+        user_id (int): The ID of the user who added the photo.
+
+    Returns:
+        Photo: The newly added photo.
+    """
+    photo = Photo(image=url, description=description, created_at=datetime.datetime.now(),
+                  updated_at=datetime.datetime.now(), rating=0, user_id=user_id)
+    db.add(photo)
+    await db.commit()
+    await db.refresh(photo)
+    return photo
+
+
+async def delete_photo(photo_id: int, db: AsyncSession):
+    """Deletes a photo from the database.
+
+    Args:
+        photo_id (int): The ID of the photo to delete.
+        db (AsyncSession): The database session.
+
+    Returns:
+        Photo: The deleted photo.
+    """
+    stmt = select(Photo).filter_by(id=photo_id)
+    # stmt = stmt.filter_by(user_id=user_id)
+    photo = await db.execute(stmt)
+    photo = photo.scalar_one_or_none()
+    if photo:
+        await db.delete(photo)
+        await db.commit()
+    return photo
+
+
+async def update_photo(
+        photo_id: int, description: str, db: AsyncSession) -> Photo:
+    """Updates description of the photo in the database.
+
+    Args:
+        photo_id (int): The ID of the photo to update.
+        description (str): The new description of the photo.
+        db (AsyncSession): The database session.
+
+    Returns:
+        Photo: The updated photo.
+    """
+    stmt = select(Photo).filter_by(id=photo_id)
+    # stmt = stmt.filter_by(user_id=user_id)
+    result = await db.execute(stmt)
+    photo = result.scalar_one_or_none()
+    if photo:
+        photo.description = description
+        photo.updated_at = datetime.datetime.now()
+        await db.commit()
+        await db.refresh(photo)
+    return photo
+
+
+async def read_photo(photo_id: int, db: AsyncSession) -> Photo | None:
+    """Gets a photo from the database.
+
+    Args:
+        photo_id (int): The ID of the photo to get.
+        db (AsyncSession): The database session.
+
+    Returns:
+        Photo | None: The photo if found, otherwise None.
+    """
+    stmt = select(Photo).filter_by(id=photo_id)
+    # stmt = stmt.filter_by(user_id=user_id)
+    photo = await db.execute(stmt)
+    return photo.scalar_one_or_none()

--- a/src/routes/photos.py
+++ b/src/routes/photos.py
@@ -1,0 +1,173 @@
+import uuid
+from urllib.parse import urlparse, unquote
+
+import cloudinary
+import cloudinary.uploader
+
+from fastapi import APIRouter, Depends, status, Path, HTTPException, UploadFile, File
+from fastapi_limiter.depends import RateLimiter
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.entity.models import User, Photo
+from src.schemas.photos import PhotosSchemaResponse
+from src.database.db import get_db
+
+from src.repository import photos as repositories_photos
+from src.services.auth import auth_service
+
+routerPhotos = APIRouter(prefix="/photos", tags=["photos"])
+
+
+@routerPhotos.post(
+    "/",
+    response_model=PhotosSchemaResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Add a new photo with its description",
+    description="Adds a new photo to the database",
+    dependencies=[Depends(RateLimiter(times=1, seconds=20))],
+)
+async def add_photo(
+        discription: str,
+        file: UploadFile = File(description="The image file to be uploaded"),
+        db: AsyncSession = Depends(get_db),
+        current_user: User = Depends(auth_service.get_current_user),
+) -> Photo:
+    """
+    Adds a new photo to the database.
+
+    Args:
+        discription (str): The description of the photo.
+        file (UploadFile, optional): The image file to be uploaded. Defaults to File.
+        db (AsyncSession, optional): The database session. Defaults to Depends(get_db).
+        current_user (User, optional): The currently authenticated user, obtained through authentication services.
+        Defaults to Depends(auth_service.get_current_user).
+
+    Returns:
+        PhotosSchemaResponse: The newly created photo.
+    """
+    public_id = f"Digital workspace/{current_user.email}/{uuid.uuid4().hex}"
+    res = cloudinary.uploader.upload(file.file, public_id=public_id, overwrite=False)
+    res_url = cloudinary.CloudinaryImage(public_id).build_url(
+        width=1000, height=1000, crop="fill", version=res.get("version")
+    )
+    photo = await repositories_photos.add_photo(
+        res_url, discription, db, current_user.id)
+
+    return photo
+
+
+@routerPhotos.delete(
+    "/{photo_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Delete a photo",
+    description="Deletes a photo from the database",
+    dependencies=[Depends(RateLimiter(times=1, seconds=20))],
+)
+async def delete_photo(
+        photo_id: int = Path(ge=1),
+        db: AsyncSession = Depends(get_db),
+        current_user: User = Depends(auth_service.get_current_user),
+):
+    """
+    Deletes a photo from the database and from Cloudinary.
+
+    Args:
+        photo_id (int): The ID of the photo to delete.
+        db (AsyncSession): The database session.
+        current_user (User): The currently authenticated user, obtained through authentication services.
+
+    Raises:
+        HTTPException: If the photo does not exist, or the user does not have permission to delete it.
+    """
+    res = await repositories_photos.read_photo(photo_id, db)
+    if not res:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Photo not found")
+    if current_user.role == "admin" or res.user_id == current_user.id:
+        image_to_delete = res.image
+        parsed_url = urlparse(image_to_delete)
+        path_parts = parsed_url.path.split('/')
+        url_image_to_delete = '/'.join(path_parts[6:])
+        decoded_public_id = unquote(url_image_to_delete)
+        result = cloudinary.uploader.destroy(public_id=decoded_public_id,
+                                             invalidate=True)
+        if result["result"] == "ok":
+            await repositories_photos.delete_photo(photo_id, db)
+        elif result["result"] == "not found":
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Photo not found in Cloudinary")
+        else:
+            raise Exception(result["result"])
+    else:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="You don't have permission")
+
+
+@routerPhotos.put(
+    "/{photo_id}",
+    response_model=PhotosSchemaResponse,
+    summary="Update description of a photo by ID",
+    description="Updates description of a photo in the database by its ID",
+    dependencies=[Depends(RateLimiter(times=1, seconds=20))],
+)
+async def update_photo(
+        photo_id: int,
+        discription: str,
+        db: AsyncSession = Depends(get_db),
+        current_user: User = Depends(auth_service.get_current_user),
+):
+    """
+    Updates description of a photo in the database by its ID.
+
+    Args:
+        photo_id (int): The ID of the photo to update.
+        discription (str): The new description of the photo.
+        db (AsyncSession): The database session.
+        current_user (User): The currently authenticated user, obtained through authentication services.
+
+    Raises:
+        HTTPException: If the photo does not exist, or the user does not have permission to update it.
+
+    Returns:
+        PhotosSchemaResponse: The updated photo.
+    """
+    res = await repositories_photos.read_photo(photo_id, db)
+    if not res:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Photo not found")
+    if current_user.role == "admin" or res.user_id == current_user.id:
+        update_photo = await repositories_photos.update_photo(photo_id, discription, db)
+        return update_photo
+    else:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="You don't have permission")
+
+
+@routerPhotos.get(
+    "/{photo_id}",
+    response_model=PhotosSchemaResponse,
+    summary="Retrieve a photo by ID",
+    description="Gets a photo from the database by its ID",
+    dependencies=[Depends(RateLimiter(times=1, seconds=20))],
+)
+async def read_photo(
+        photo_id: int = Path(ge=1),
+        db: AsyncSession = Depends(get_db),
+        current_user: User = Depends(auth_service.get_current_user),
+):
+    """
+    Gets a photo from the database by its ID.
+
+    Args:
+        photo_id (int): The ID of the photo to retrieve.
+        db (AsyncSession): The database session.
+        current_user (User): The currently authenticated user, obtained through authentication services.
+
+    Raises:
+        HTTPException: If the photo does not exist, or the user does not have permission to read it.
+
+    Returns:
+        PhotosSchemaResponse: The retrieved photo.
+    """
+    photo = await repositories_photos.read_photo(photo_id, db)
+    if not photo:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Photo not found")
+    if photo.user_id == current_user.id or current_user.role == "admin":
+        return photo
+    else:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="You don't have permission")

--- a/src/schemas/photos.py
+++ b/src/schemas/photos.py
@@ -1,0 +1,18 @@
+from datetime import datetime
+from pydantic import BaseModel
+
+
+class PhotoValidationSchema(BaseModel):
+    image: str
+    description: str
+    rating: int
+
+
+class PhotosSchemaResponse(PhotoValidationSchema):
+    id: int = 1
+    image: str
+    description: str
+    rating: int
+    user_id: int
+    created_at: datetime
+    updated_at: datetime


### PR DESCRIPTION
CRUD operations with PHOTOS:
- **Create a new photo**
- `POST /api/photos/`
- Create a new photo with a description
- available to all users

- **Delete photo by ID**
- `DELETE /api/photos/{photo_id}`
- Delete photo from the database and from Cloud
- Available only to photo owners and administrators

- **Update photo description by ID**
- `PUT /api/photos/{photo_id}`
- Update description of an existing photo
- - Available only to photo owners and administrators

- **Get a photo by ID**
- `GET /api/photos/{photo_id}`
- Get a specific photo by its ID
- Available only to photo owners and administrators